### PR TITLE
bfd: Modify license to GPLv2

### DIFF
--- a/bfd.c
+++ b/bfd.c
@@ -2,10 +2,19 @@
  * Copyright 2013 Cumulus Networks, LLC.  All rights reserved.
  * Copyright 2014,2015,2016,2017 Cumulus Networks, Inc.  All rights reserved.
  *
- * This file is licensed to You under the Eclipse Public License (EPL);
- * You may not use this file except in compliance with the License. You
- * may obtain a copy of the License at
- * http://www.opensource.org/licenses/eclipse-1.0.php
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * ptm_bfd.[ch] implements the BFD protocol and interacts with
  * other ptm modules

--- a/bfd.h
+++ b/bfd.h
@@ -1,10 +1,20 @@
 /*********************************************************************
  * Copyright 2014,2015,2016,2017 Cumulus Networks, Inc.  All rights reserved.
  *
- * This file is licensed to You under the Eclipse Public License (EPL);
- * You may not use this file except in compliance with the License. You
- * may obtain a copy of the License at
- * http://www.opensource.org/licenses/eclipse-1.0.php
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
  */
 
 #ifndef _BFD_H_

--- a/bfd_packet.c
+++ b/bfd_packet.c
@@ -1,10 +1,19 @@
 /*********************************************************************
  * Copyright 2017 Cumulus Networks, Inc.  All rights reserved.
  *
- * This file is licensed to You under the Eclipse Public License (EPL);
- * You may not use this file except in compliance with the License. You
- * may obtain a copy of the License at
- * http://www.opensource.org/licenses/eclipse-1.0.php
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * ptm_bfd.[ch] implements the BFD protocol and interacts with
  * other ptm modules


### PR DESCRIPTION
The Cumulus code was licensed under a restrictive license due to original
constraint of having to link against a library.  With the removal of the library
it is no longer necessary to have that license.  Switch to GPLv2

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>