### PR TITLE
Fix "multiple definitions" build error

### DIFF
--- a/bfd.h
+++ b/bfd.h
@@ -303,13 +303,13 @@ struct bfd_vrf {
 	int vrf_id;
 	char name[MAXNAMELEN + 1];
 	UT_hash_handle vh;
-} bfd_vrf;
+};
 
 struct bfd_iface {
 	int vrf_id;
 	char ifname[MAXNAMELEN + 1];
 	UT_hash_handle ifh;
-} bfd_iface;
+};
 
 
 /* States defined per 4.1 */


### PR DESCRIPTION
There are two global variables defined in bfd.h: `bfd_vrf` and `bfd_iface`.

They are causing "multiple definitions" error when linking, since bfd.h is included in both bfd.c and bfdd.c (and possibly other files), so both bfd.o and bfdd.o end up having definitions of the same global variable, which `ld` refuses to deal with.

One way to fix this would be to make them `extern` in the header, and then define them as non-extern in one of the c files.

However, they don't seem to be used anywhere, so just remove them and only keep the struct definitions.