### PR TITLE
Fix crash when removing and re-adding peers with labels

### DIFF
--- a/bfd.c
+++ b/bfd.c
@@ -742,6 +742,9 @@ void bfd_session_free(bfd_session *bs)
 	bfd_xmttimer_delete(bs);
 	bfd_echo_xmttimer_delete(bs);
 
+	if (bs->pl != NULL)
+		pl_free(bs->pl);
+
 	HASH_DELETE(sh, session_hash, bs);
 	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
 		HASH_DELETE(mh, local_peer_hash, bs);

--- a/bfd.h
+++ b/bfd.h
@@ -445,6 +445,7 @@ int config_notify_request(struct bfd_control_socket *bcs, const char *jsonstr,
 
 struct peer_label *pl_new(const char *label, bfd_session *bs);
 struct peer_label *pl_find(const char *label);
+void pl_free(struct peer_label *pl);
 
 
 /*

--- a/bfd_config.c
+++ b/bfd_config.c
@@ -64,8 +64,6 @@ int json_object_add_bool(struct json_object *jo, const char *key, bool boolean);
 int json_object_add_int(struct json_object *jo, const char *key, int64_t value);
 int json_object_add_peer(struct json_object *jo, bfd_session *bs);
 
-void pl_free(struct peer_label *pl);
-
 
 /*
  * Implementation


### PR DESCRIPTION
In bfd_session_free, remember to also free the label if there is one.

Otherwise, removing a session would leave a struct peer_label still on the bg_pllist, containing a pointer to a freed bfd_session.

If a session with the same label was subsequently added, ptm_bfd_sess_new would find the freed session through the label, and instead of creating a new one, try to update the freed one, leading to various use-after-free accesses.

It looks like this cannot be triggered by bfdctl.
I only found it because, frustrated with bfdctl's limitations, I started sending custom JSONs directly to the control socket.